### PR TITLE
Add card deck in circular layout

### DIFF
--- a/Circle of death/Card.swift
+++ b/Circle of death/Card.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+enum Suit: String, CaseIterable, Identifiable {
+    case hearts = "♥"
+    case diamonds = "♦"
+    case clubs = "♣"
+    case spades = "♠"
+
+    var id: String { rawValue }
+
+    var color: Color {
+        switch self {
+        case .hearts, .diamonds:
+            return .red
+        case .clubs, .spades:
+            return .black
+        }
+    }
+}
+
+struct Card: Identifiable {
+    let id = UUID()
+    let rank: String
+    let suit: Suit
+
+    static let ranks = ["2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K", "A"]
+
+    static var deck: [Card] {
+        Suit.allCases.flatMap { suit in
+            ranks.map { rank in
+                Card(rank: rank, suit: suit)
+            }
+        }
+    }
+}
+
+struct CardView: View {
+    let card: Card
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 5)
+                .fill(Color.white)
+                .shadow(radius: 1)
+            VStack(spacing: 2) {
+                Text(card.rank)
+                    .font(.caption)
+                    .bold()
+                Text(card.suit.rawValue)
+                    .font(.caption2)
+            }
+            .foregroundColor(card.suit.color)
+        }
+        .overlay(
+            RoundedRectangle(cornerRadius: 5)
+                .stroke(Color.black, lineWidth: 1)
+        )
+    }
+}

--- a/Circle of death/ContentView.swift
+++ b/Circle of death/ContentView.swift
@@ -8,14 +8,28 @@
 import SwiftUI
 
 struct ContentView: View {
+    private let cards = Card.deck
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Moin!")
+        GeometryReader { geometry in
+            ZStack {
+                ForEach(cards.indices, id: \.self) { index in
+                    CardView(card: cards[index])
+                        .frame(width: 40, height: 60)
+                        .position(position(for: index, in: geometry.size))
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color.green.opacity(0.2))
         }
-        .padding()
+    }
+
+    private func position(for index: Int, in size: CGSize) -> CGPoint {
+        let angle = 2 * Double.pi * Double(index) / Double(cards.count)
+        let radius = min(size.width, size.height) / 2 - 50
+        let x = size.width / 2 + CGFloat(cos(angle)) * radius
+        let y = size.height / 2 + CGFloat(sin(angle)) * radius
+        return CGPoint(x: x, y: y)
     }
 }
 

--- a/Circle of deathTests/Circle_of_deathTests.swift
+++ b/Circle of deathTests/Circle_of_deathTests.swift
@@ -10,8 +10,8 @@ import Testing
 
 struct Circle_of_deathTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    @Test func testDeckContains52Cards() async throws {
+        #expect(Card.deck.count == 52)
     }
 
 }


### PR DESCRIPTION
## Summary
- implement `Card` model and `CardView`
- show 52-card deck in a circle
- add test verifying deck size

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686a69793854832ab505d362bde75944