### PR TITLE
Add interactive card draw

### DIFF
--- a/Circle of death/Card.swift
+++ b/Circle of death/Card.swift
@@ -36,20 +36,29 @@ struct Card: Identifiable {
 
 struct CardView: View {
     let card: Card
+    var faceUp: Bool = false
 
     var body: some View {
         ZStack {
-            RoundedRectangle(cornerRadius: 5)
-                .fill(Color.white)
-                .shadow(radius: 1)
-            VStack(spacing: 2) {
-                Text(card.rank)
-                    .font(.caption)
-                    .bold()
-                Text(card.suit.rawValue)
-                    .font(.caption2)
+            if faceUp {
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(Color.white)
+                    .shadow(radius: 1)
+                VStack(spacing: 2) {
+                    Text(card.rank)
+                        .font(.caption)
+                        .bold()
+                    Text(card.suit.rawValue)
+                        .font(.caption2)
+                }
+                .foregroundColor(card.suit.color)
+            } else {
+                RoundedRectangle(cornerRadius: 5)
+                    .fill(Color.blue)
+                    .shadow(radius: 1)
+                Image(systemName: "questionmark")
+                    .foregroundColor(.white)
             }
-            .foregroundColor(card.suit.color)
         }
         .overlay(
             RoundedRectangle(cornerRadius: 5)

--- a/Circle of death/ContentView.swift
+++ b/Circle of death/ContentView.swift
@@ -8,15 +8,45 @@
 import SwiftUI
 
 struct ContentView: View {
-    private let cards = Card.deck
+    @State private var deck = Card.deck
+    @State private var selectedCard: Card? = nil
+    @State private var discards: [Card] = []
 
     var body: some View {
         GeometryReader { geometry in
             ZStack {
-                ForEach(cards.indices, id: \.self) { index in
-                    CardView(card: cards[index])
+                ForEach(deck.indices, id: \.self) { index in
+                    let card = deck[index]
+                    CardView(card: card)
                         .frame(width: 40, height: 60)
                         .position(position(for: index, in: geometry.size))
+                        .onTapGesture {
+                            withAnimation(.spring()) {
+                                selectedCard = card
+                                deck.removeAll { $0.id == card.id }
+                            }
+                        }
+                }
+
+                if let card = selectedCard {
+                    CardView(card: card, faceUp: true)
+                        .frame(width: 200, height: 300)
+                        .zIndex(1)
+                        .transition(.asymmetric(insertion: .scale, removal: .opacity))
+                        .onTapGesture {
+                            withAnimation(.spring()) {
+                                discards.append(card)
+                                selectedCard = nil
+                            }
+                        }
+                }
+
+                ForEach(discards.indices, id: \.self) { index in
+                    let card = discards[index]
+                    CardView(card: card, faceUp: true)
+                        .frame(width: 40, height: 60)
+                        .position(x: geometry.size.width - 30,
+                                  y: geometry.size.height - CGFloat(index * 15 + 50))
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -25,7 +55,7 @@ struct ContentView: View {
     }
 
     private func position(for index: Int, in size: CGSize) -> CGPoint {
-        let angle = 2 * Double.pi * Double(index) / Double(cards.count)
+        let angle = 2 * Double.pi * Double(index) / Double(deck.count)
         let radius = min(size.width, size.height) / 2 - 50
         let x = size.width / 2 + CGFloat(cos(angle)) * radius
         let y = size.height / 2 + CGFloat(sin(angle)) * radius


### PR DESCRIPTION
## Summary
- show card backs by default and reveal when selected
- allow selecting a card from the circle
- animate drawing the card and move it aside when tapped again

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_686a6b6f1628832aae85ed897b791b63